### PR TITLE
Fix for Apple Payments Generic Label

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,17 @@ Future<void> validateApi() async {
 
 ## Apple pay
 
+Apple Pay requires payment summary items that clearly identify who the payment is going to, per [Apple's Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/apple-pay). Pass one or more entries in `paymentSummaryItems` — a single charge is just an array with one item.
+
 ``` js
 
   try {
 
     var params = {
-      "displayAmount": '1000', 
+      "paymentSummaryItems": [
+        {"label": "Merchant Name Item", "amount": "100.00"},
+        {"label": "Merchant Name", "amount": "100.00"},
+      ],
       "merchantIdentifier": "merchant.com.*",
       "countryCode": 'AE',
       "currencyCode": 'AED',
@@ -138,11 +143,19 @@ Future<void> validateApi() async {
 
 ```
 
+Single line item example:
+
+``` js
+"paymentSummaryItems": [
+  {"label": "Merchant Name", "amount": "100.00"},
+],
+```
+
 ### Apple Pay props (ApplePayRequest)
 
 | Attribute            | Type         | Description                                                                                                                                                                                                                                                                        | Mandatory | Maximum | Example                                                               |
 |----------------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|---------|-----------------------------------------------------------------------|
-| displayAmount              | Alpha        | The amount to be display on the Apple payment screen                                                                                                                                                                              | Yes       | 10      | 100                                                              |
+| paymentSummaryItems  | `array`      | Charges shown on the Apple Pay sheet. Each entry requires `label` (payee or item description) and `amount`. The last item is typically the merchant total. For a single charge, pass an array with one entry. | Yes       |         | `[{"label": "Merchant Name Items", "amount": "100.00"}, {"label": "Merchant Name", "amount": "100.00"}]` |
 | environment                              | `'TEST'`, `'PRODUCTION'`     | Parameter used to determine whether the request is going to be submitted to the test or production environment. |      Yes      |
 | merchantIdentifier | Alphanumeric    | The apple pay merchant identifier created on the apple developer account |      Yes      | 150  | merchant.com.test.integration|
 | countryCode | Alpha | A list of two-letter country codes for limiting payment to cards from specific countries or regions. | Yes | 2 | AE|

--- a/example/lib/ui/main/main_screen.dart
+++ b/example/lib/ui/main/main_screen.dart
@@ -369,7 +369,10 @@ class _MainScreen extends State<MainScreen> {
     transactionDetails.remove('country_code');
 
     var params = {
-      "displayAmount": requestParam['amount'], // Ensure it's a string
+      "paymentSummaryItems": [
+        {"label": "Merchant Order", "amount": requestParam['amount']},
+        {"label": "Your Merchant Name", "amount": requestParam['amount']},
+      ],
       "merchantIdentifier": "merchant.com.",
       'countryCode': requestParam['country_code'],
       'currencyCode': requestParam['currency'],

--- a/ios/Classes/SwiftFlutterAmazonpaymentservicesPlugin.swift
+++ b/ios/Classes/SwiftFlutterAmazonpaymentservicesPlugin.swift
@@ -95,12 +95,20 @@ public class SwiftFlutterAmazonpaymentservicesPlugin: NSObject, FlutterPlugin {
         payFortController = PayFortController.init(enviroment: .production)
       }
 
-      guard let amount = requestParam["displayAmount"] as? String,
-          let countryCode = requestParam["countryCode"] as? String,
+      guard let countryCode = requestParam["countryCode"] as? String,
           let currencyCode = requestParam["currencyCode"] as? String,
           let supportedNetworks = requestParam["supportedNetworks"] as? [String],
           let merchantId = requestParam["merchantIdentifier"] as? String else {
           result(FlutterError(code: "INVALID_PARAMETERS", message: "Missing required Apple Pay parameters", details: requestParam))
+          return
+      }
+
+      guard let paymentSummaryItems = buildPaymentSummaryItems(from: requestParam),
+          !paymentSummaryItems.isEmpty else {
+          result(FlutterError(
+              code: "INVALID_PARAMETERS",
+              message: "Missing paymentSummaryItems. Each entry requires label and amount.",
+              details: requestParam))
           return
       }
 
@@ -132,9 +140,7 @@ public class SwiftFlutterAmazonpaymentservicesPlugin: NSObject, FlutterPlugin {
           }
       }
 
-      paymentRequest.paymentSummaryItems = [
-          PKPaymentSummaryItem(label: "Total", amount: NSDecimalNumber(string: amount))
-      ]
+      paymentRequest.paymentSummaryItems = paymentSummaryItems
 
       guard let viewController = UIApplication.shared.windows.first?.rootViewController else {
           result(FlutterError(code: "NO_VIEW_CONTROLLER", message: "No view controller available", details: nil))
@@ -149,6 +155,32 @@ public class SwiftFlutterAmazonpaymentservicesPlugin: NSObject, FlutterPlugin {
           result(FlutterError(code: "APPLE_PAY_UNAVAILABLE", message: "Unable to present Apple Pay", details: nil))
       }
 
+  }
+
+  private func buildPaymentSummaryItems(from requestParam: [String: Any]) -> [PKPaymentSummaryItem]? {
+      guard let summaryItems = requestParam["paymentSummaryItems"] as? [[String: Any]] else {
+          return nil
+      }
+
+      let items = summaryItems.compactMap { item -> PKPaymentSummaryItem? in
+          guard let label = item["label"] as? String, !label.isEmpty,
+              let amount = parseAmount(from: item["amount"]) else {
+              return nil
+          }
+          return PKPaymentSummaryItem(label: label, amount: amount)
+      }
+
+      return items.isEmpty ? nil : items
+  }
+
+  private func parseAmount(from value: Any?) -> NSDecimalNumber? {
+      if let amount = value as? String, !amount.isEmpty {
+          return NSDecimalNumber(string: amount)
+      }
+      if let amount = value as? NSNumber {
+          return NSDecimalNumber(decimal: amount.decimalValue)
+      }
+      return nil
   }
 }
 


### PR DESCRIPTION
Issue Summary:
Apple identified that the Apple Pay payment sheet does not display the merchant name prior to payment authorization. According to Apple’s guidelines, users must clearly see the merchant/business name before confirming the transaction. 

Current Issue:
The Apple Pay payment summary items are likely using a generic label such as: 
“Total”
“Payment”
“Amount”
instead of the actual merchant name.

Required Fix:
Please update the Apple Pay configuration so that the final payment summary item displays the merchant name clearly based on the merchant on APS. Flutter / APS Expected Configuration Example:
payment_summary_items: [
  {
    "label": "Merchant Name Items",
    "amount": "100.00"
  },
  {
    "label": "Merchant Name",
    "amount": "100.00"
  }
]